### PR TITLE
Update translation of gems-with-extensions.md

### DIFF
--- a/gems-with-extensions.md
+++ b/gems-with-extensions.md
@@ -7,7 +7,7 @@ next: /name-your-gem
 alias: /c-extensions
 ---
 
-<em class="t-gray">인스톨할 때 빌드되는 확장기능을 가진 gem 만들기</em>
+<em class="t-gray">설치할 때 빌드되는 확장기능을 가진 gem 만들기</em>
 
 많은 gem이 c로 짜인 라이브러리를 루비로 래핑해서 사용합니다. 예를 들어
 [nokogiri](https://rubygems.org/gems/nokogiri)는
@@ -26,30 +26,31 @@ alias: /c-extensions
 Gem 레이아웃
 ----------
 
-모든 gem은 개발자가 작업할 때 필요한 태스크가 들어 있는 Rakefile부터 만들어야
-합니다. 확장기능용 파일은 `ext/` 디렉터리 안의 확장기능 이름과 같은 디렉터리에
+모든 gem은 개발자가 작업할 때 필요한 작업이 들어 있는 Rakefile부터 만들어야
+합니다. 확장기능용 파일은 `ext/` 디렉토리 안의 확장기능 이름과 같은 디렉토리에
 들어가야 합니다. 이 예제에서는 "my_malloc"이라는 이름을 사용하겠습니다.
 
-어떤 확장기능은 어떤 곳은 C로 나머지는 루비로 구현됩니다. C, 자바 확장기능 같은
-여러 언어를 지원할 생각이라면, C-specific 루비 파일을 `ext/` 디렉터리뿐만
-아니라 `lib/` 디렉터리에도 넣으셔야 합니다.
+어떤 확장기능은 일부는 C로, 일부는 루비로 구현됩니다. C, 자바 확장기능 같은
+여러 언어를 지원할 생각이라면, C-specific 루비 파일을 `ext/` 디렉토리뿐만
+아니라 `lib/` 디렉토리에도 넣으셔야 합니다.
 
     Rakefile
     ext/my_malloc/extconf.rb               # extension configuration
     ext/my_malloc/my_malloc.c              # extension source
     lib/my_malloc.rb                       # generic features
 
-확장기능이 `ext/my_malloc/lib/`안에 파일을 만들면 `lib/` 디렉터리에 인스톨됩니다.
+확장기능이 빌드될 때, `ext/my_malloc/lib/` 안의 파일이 `lib/` 디렉토리에
+설치됩니다.
 
 extconf.rb
 ----------
 
 extconf.rb는 확장기능을 빌드할 Makefile을 설정합니다. extconf.rb는 확장기능에서
-필요한 기능, 매크로, 공유 라이브러리를 체크해야 합니다. 이 중 빠진 것이 있으면
+필요한 함수, 매크로, 공유 라이브러리를 체크해야 합니다. 이 중 빠진 것이 있으면
 extconf.rb는 에러와 함께 종료되어야 합니다.
 
-이 extconf.rb는 `malloc()`, `free()`와 확장기능을
-`lib/my_malloc/my_malloc.so`에 설치 할 Makefile을 체크합니다.
+이 extconf.rb는 `malloc()`, `free()`를 체크하고, 확장기능을
+`lib/my_malloc/my_malloc.so`에 설치 할 Makefile을 생성합니다.
 
     require "mkmf"
 
@@ -58,7 +59,7 @@ extconf.rb는 에러와 함께 종료되어야 합니다.
 
     create_makefile "my_malloc/my_malloc"
 
-extconf.rb의 작성과 메서드들의 더 자세한 정보는 [mkmf 문서][mkmf.rb]와
+extconf.rb의 작성과 관련 메소드의 더 자세한 정보는 [mkmf 문서][mkmf.rb]와
 [README.EXT][README.EXT]를 살펴보세요.
 
 C 확장기능
@@ -136,14 +137,14 @@ C 확장기능
       rb_define_method(cMyMalloc, "free", my_malloc_release, 0);
     }
 
-이 확장기능은 간단한 몇가지 기능만 있습니다.
+이 확장기능은 간단한 몇 가지 기능만 있습니다.
 
-* `struct my_malloc` 는 할당된 메모리를 유지합니다.
-* `my_malloc_free()` 는 가비지 콜렉션 이후 할당된 메모리를 해제합니다.
-* `my_malloc_alloc()` 는 루비 래퍼 객체를 생성합니다.
-* `my_malloc_init()` 는 루비에서 메모리를 할당합니다.
-* `my_malloc_release()` 는 루비에서 메모리를 해제합니다.
-* `Init_my_malloc()` 는 `MyMalloc`클래스에 함수를 등록합니다.
+* `struct my_malloc`는 할당된 메모리를 유지합니다.
+* `my_malloc_free()`는 가비지 콜렉션 이후 할당된 메모리를 해제합니다.
+* `my_malloc_alloc()`는 루비 래퍼 객체를 생성합니다.
+* `my_malloc_init()`는 루비에서 메모리를 할당합니다.
+* `my_malloc_release()`는 루비에서 메모리를 해제합니다.
+* `Init_my_malloc()`는 `MyMalloc` 클래스에 함수를 등록합니다.
 
 확장기능의 빌드는 이렇게 테스트 할 수 있습니다.
 
@@ -159,16 +160,16 @@ C 확장기능
     $ ruby -Ilib:ext -r my_malloc -e "p MyMalloc.new(5).free"
     #<MyMalloc:0x007fed838addb0>
 
-음.. 따분한 일이네요. 자동화합시다!
+음... 따분한 일이네요. 자동화합시다!
 
 rake-compiler
 -------------
 
-[rake-compiler][rake-compiler]는 확장기능 빌드를 자동화하기 위한 rake 태스크의
+[rake-compiler][rake-compiler]는 확장기능 빌드를 자동화하기 위한 rake 작업의
 모음입니다. rake-compiler는 같은 프로젝트 안의 C나 자바 확장기능과 함께
 사용할 수 있습니다. (nokogiri가 이런 식으로 씁니다.)
 
-rake-compiler는 쉽게 넣을 수 있습니다.
+rake-compiler는 쉽게 추가할 수 있습니다.
 
     require "rake/extensiontask"
 
@@ -176,12 +177,12 @@ rake-compiler는 쉽게 넣을 수 있습니다.
       ext.lib_dir = "lib/my_malloc"
     end
 
-이제 `rake compile`으로 확장기능을 빌드할 수 있습니다. 다른 태스크(테스트 같은)
-사이에 컴파일 태스크를 넣을 수 있습니다.
+이제 `rake compile`으로 확장기능을 빌드할 수 있습니다. 다른 작업(테스트 같은)
+사이에 컴파일 작업을 넣을 수 있습니다.
 
-`lib_dir` 설정은 `lib/my_malloc/my_malloc.so`(나 `.bundle`이나 `.dll`)에 공유
-라이브러리를 넣습니다. 이렇게하면, gem을 위한 최상위 파일은 루비파일이 되고,
-루비 파일에서 루비에 맞도록 최적화된 코드를 짤 수 있습니다.
+`lib_dir` 설정은 `lib/my_malloc/my_malloc.so`(또는 `.bundle`이나 `.dll`)에 공유
+라이브러리를 둡니다. 이렇게 하면, gem의 최상위 파일은 루비파일이 되고,
+루비를 쓰기에 알맞은 부분은 루비로 짤 수 있습니다.
 
 예를 들어:
 
@@ -193,15 +194,15 @@ rake-compiler는 쉽게 넣을 수 있습니다.
 
     require "my_malloc/my_malloc"
 
-`lib_dir` 설정으로 여러 버전의 루비를 위한 확장기능을 미리 빌드한 gem을 빌드할
+`lib_dir` 설정으로 여러 버전의 루비를 위해 빌드된 확장기능을 포함한 gem을 빌드할
 수도 있습니다. (루비 1.9.3 확장기능은 루비 2.0.0의 확장기능과 같이 사용할 수
-없습니다.) `lib/my_malloc.rb`은 인스톨할 때 맞는 공유 라이브러리를 고를 수
+없습니다.) `lib/my_malloc.rb`은 설치할 때 맞는 공유 라이브러리를 고를 수
 있습니다.
 
 Gemspec
 -----------------
 
-gem을 만들기 위한 마지막 단계는 gemspec의 확장기능 목록에 extconf.rb 추가입니다.
+gem을 만들기 위해 마지막으로 gemspec의 확장기능 목록에 extconf.rb를 추가합니다.
 
     Gem::Specification.new "my_malloc", "1.0" do |s|
       # [...]
@@ -214,31 +215,31 @@ gem을 만들기 위한 마지막 단계는 gemspec의 확장기능 목록에 ex
 확장기능 이름짓기
 ----------------
 
-gem 사이의 의도치 않은 상호작용을 피하기 위해, 각 gem은 파일을 한 디렉터리에
-넣어두면 좋습니다. `<name>`이라는 gem이 있다면 권장되는 구성은 이렇습니다.
+gem 사이의 의도치 않은 상호작용을 피하기 위해, 각 gem의 파일을 한 디렉토리에
+넣어두면 좋습니다. `<name>`이라는 gem을 아래와 같이 구성하는 것을 권장합니다.
 
-1. `ext/<name>`은 `extconf.rb`, 소스 파일을 포함하는 디렉터리입니다.
-2. `ext/<name>/<name>.c`은 메인 소스 파일(다른 파일도 있겠죠?)입니다.
-3. `ext/<name>/<name>.c`은 `Init_<name>` 함수를 포함합니다. (require로 불러오려면
+1. `ext/<name>`은 `extconf.rb`, 소스 파일을 포함하는 디렉토리입니다.
+2. `ext/<name>/<name>.c`는 메인 소스 파일(다른 파일도 있겠죠?)입니다.
+3. `ext/<name>/<name>.c`는 `Init_<name>` 함수를 포함합니다. (require로 불러오려면
    `Init_` 함수 뒤의 이름은 확장기능의 이름과 정확히 같아야 합니다.
 4. `ext/<name>/extconf.rb`는 확장기능을 컴파일하는 데 필요한 모든 요소가
    존재하는 경우에만 `create_makefile('<name>/<name>')`를 호출합니다.
-5. gemspec에 `extensions = ['ext/<name>/extconf.rb']`과 필요한 확장기능의 소스
+5. gemspec에 `extensions = ['ext/<name>/extconf.rb']`와 필요한 확장기능의 소스
    파일을 전부 `files` 목록에 추가합니다.
-6. `lib/<name>.rb` C 확장기능을 로드할 `require '<name>/<name>'`를 포함합니다.
+6. `lib/<name>.rb`는 C 확장기능을 로드할 `require '<name>/<name>'`을 포함합니다.
 
 더 읽을거리
 ---------------
 
-* [my_malloc](https://github.com/rubygems/guides/tree/my_malloc)는 이 확장
+* [my_malloc](https://github.com/rubygems/guides/tree/my_malloc)은 이 확장
   기능의 소스에 주석을 조금 덧붙여 놓았습니다.
 * [README.EXT][README.EXT]는 훨씬 더 자세하게 어떻게 루비에서 확장기능을
   빌드하는지 설명합니다.
-* [MakeMakefile][mkmf.rb]에는 mkmf.rb의 문서가 있습니다.  mkmf.rb는 extconf.rb
+* [MakeMakefile][mkmf.rb]에는 mkmf.rb의 문서가 있습니다. mkmf.rb는 extconf.rb
   라이브러리에서 루비와 C 라이브러리 기능을 찾는데 사용합니다.
-* [rake-compiler][rake-compiler]는 C와 자바 확장기능의 빌드를 자연스럽게 
+* [rake-compiler][rake-compiler]는 C와 자바 확장기능의 빌드를 자연스럽게
   Rakefile에 넣습니다.
-* Aaron Patterson님의 [C 확장기능 파트
+* Aaron Patterson 님의 [C 확장기능 파트
   1](http://tenderlovemaking.com/2009/12/18/writing-ruby-c-extensions-part-1.html),
   [파트 2](http://tenderlovemaking.com/2010/12/11/writing-ruby-c-extensions-part-2.html)
 * C 라이브러리의 인터페이스는 루비를 사용해 작성할 수 있습니다.
@@ -248,4 +249,3 @@ gem 사이의 의도치 않은 상호작용을 피하기 위해, 각 gem은 파�
 [README.EXT]: https://github.com/ruby/ruby/blob/trunk/README.EXT
 [mkmf.rb]: http://ruby-doc.org/stdlib-2.0/libdoc/mkmf/rdoc/MakeMakefile.html
 [rake-compiler]: https://github.com/luislavena/rake-compiler
-

--- a/index.md
+++ b/index.md
@@ -5,7 +5,7 @@ previous: /credits
 next: /rubygems-basics
 ---
 
-<em class="t-gray">RubyGems가 어떻게 동작하는지와 어떻게 직접 만드는지 배웁시다.</em>
+<em class="t-gray">RubyGems가 어떻게 동작하는지와 어떻게 직접 만드는지 배우기</em>
 
 RubyGems 소프트웨어는 시스템에서 루비 소프트웨어 패키지를 쉽게 다운로드,
 설치, 관리하도록 합니다. 소프트웨어 패키지는 "gem"이라 불리고 루비

--- a/make-your-own-gem.md
+++ b/make-your-own-gem.md
@@ -6,7 +6,7 @@ previous: /what-is-a-gem
 next: /gems-with-extensions
 ---
 
-<em class="t-gray">처음부터 끝까지, 루비 코드를 어떻게 gem으로 패키징 하는지 배우기.</em>
+<em class="t-gray">처음부터 끝까지, 루비 코드를 어떻게 gem으로 패키징 하는지 배우기</em>
 
 * [서론](#introduction)
 * [당신의 첫 번째 gem](#your-first-gem)

--- a/what-is-a-gem.md
+++ b/what-is-a-gem.md
@@ -6,7 +6,7 @@ previous: /rubygems-basics
 next: /make-your-own-gem
 ---
 
-<em class="t-gray">RubyGem 안에 무엇이 들어있는지 미스터리 파헤치기.</em>
+<em class="t-gray">RubyGem 안에 무엇이 들어있는지 미스터리 파헤치기</em>
 
 gem의 구조
 ------------------


### PR DESCRIPTION
- Use constant style of writing for summary
  - `<em class="t-gray">`에 쓰인 문장이 모두 '~하기'로 끝나도록 바꿨습니다.
- Remove trailing whitespace
- Fix spacing
- Translate borrowed words to Korean
  - 인스톨 → 설치
  - 태스크 → 작업: 대부분 `rake`나 `Rakefile`과 함께 쓰여서 혼동할 여지가 없다고 판단했습니다.
  - 디렉터리 → 디렉토리
  - 메서드 → 메소드
- Fix Korean postpositions
  - 앞에 오는 영어 단어 발음에 맞춰 조사를 고쳤습니다.
